### PR TITLE
Add include guards

### DIFF
--- a/editor.h
+++ b/editor.h
@@ -1,3 +1,5 @@
+#ifndef EDITOR_H
+#define EDITOR_H
 #pragma once
 #include <QtCore>
 #include <QMenu>
@@ -28,3 +30,4 @@ private:
     int numCharacters = 0;             // Number of characters in file
     const int MAX_CHARACTERS = 6;      // Maximum number of characters allowed by RogueLands
 };
+#endif

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -1,3 +1,5 @@
+#ifndef MAINWINDOW_H
+#define MAINWINDOW_H
 #pragma once
 #include <QMainWindow>
 #include <QToolButton>
@@ -24,3 +26,4 @@ private:
     Editor* e;
     Ui::MainWindow *ui;
 };
+#endif

--- a/strings.h
+++ b/strings.h
@@ -1,3 +1,5 @@
+#ifndef STRINGS_H
+#define STRINGS_H
 #pragma once
 #include <string>
 #include <QString>
@@ -35,3 +37,4 @@ namespace Strings
     static const std::string stringSpecifier = "System.String";
     static const std::string nameSpecifier = "name";
 }
+#endif


### PR DESCRIPTION
Pragma once is not a sufficient guard against double includes.

This is both good practice and more portable.

Really, Murphy, this should be standard practice!
